### PR TITLE
Include private organizations and repositories in the pull-requests

### DIFF
--- a/lib/furik/pull_requests.rb
+++ b/lib/furik/pull_requests.rb
@@ -67,7 +67,7 @@ module Furik
     end
 
     def user_repo_names
-      @client.repos(@login).map(&:full_name)
+      @client.repos.map(&:full_name)
     end
 
     def user_orgs_names

--- a/lib/furik/pull_requests.rb
+++ b/lib/furik/pull_requests.rb
@@ -71,7 +71,7 @@ module Furik
     end
 
     def user_orgs_names
-      @client.orgs(@login).map(&:login)
+      @client.orgs.map(&:login)
     end
 
     def org_repo_names(org_name)


### PR DESCRIPTION
This changes has used "[list-your-orgs](https://developer.github.com/v3/orgs/#list-your-organizations)" instead of "[list-user-orgs](https://developer.github.com/v3/orgs/#list-user-organizations)" in pulls command. Similarly in repository.