### PR TITLE
Add a option '--on' to 'furik activity'

### DIFF
--- a/lib/furik/cli.rb
+++ b/lib/furik/cli.rb
@@ -46,20 +46,26 @@ module Furik
     method_option :since, type: :numeric, aliases: '-d', default: 0
     method_option :from, type: :string, aliases: '-f', default: Date.today.to_s
     method_option :to, type: :string, aliases: '-t', default: Date.today.to_s
+    method_option :on, type: :string, aliases: '-o'
     def activity
-      from = Date.parse(options[:from])
-      to   = Date.parse(options[:to])
+      on = Date.parse(options[:on]) if options[:on]
+      from = on || Date.parse(options[:from])
+      to   = on || Date.parse(options[:to])
       since = options[:since]
 
       diff = (to - from).to_i
       diff.zero? ? from -= since : since = diff
 
-      period = case since
-      when 999 then 'All'
-      when 0 then "Today's"
-      else "#{since + 1}days"
+      if on
+        puts "Activities on #{on}"
+      else
+        period = case since
+                 when 999 then 'All'
+                 when 0 then "Today's"
+                 else "#{since + 1}days"
+                 end
+        puts "#{period} Activities"
       end
-      puts "#{period} Activities"
       puts '-'
       puts ''
 

--- a/lib/furik/version.rb
+++ b/lib/furik/version.rb
@@ -1,3 +1,3 @@
 module Furik
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
I add a option '--on' to 'furik activity' command.
This option makes easy to show activities on a day.
Currently, to show it, we need to specify a date to both '--from' and '--to' options like below.

```sh
$ furik activity --from 2016-09-01 --to 2016-09-01
```

By using '--on' option, we can show it easily.

```sh
$ furik activity --on 2016-09-01
```