### PR TITLE
リンクのテキストはタイトルのほうがよい

### DIFF
--- a/lib/furik/cli.rb
+++ b/lib/furik/cli.rb
@@ -24,8 +24,7 @@ module Furik
             next if start_date && date < start_date
             next if end_date && date > end_date
 
-            memo << "- [#{issue.number} #{issue.state}](#{issue.html_url}):"
-            memo << " #{issue.title}"
+            memo << "- [#{issue.title}](#{issue.html_url}):"
             memo << " (#{issue.body.plain.cut})" if issue.body && !issue.body.empty?
             memo << " #{issue.created_at.localtime.to_date}\n"
           end


### PR DESCRIPTION
furikを利用する際に、リンクのテキストはほとんどIssue、PRのタイトルに置き換えられているので、置き換えが不要なようにタイトルをリンクのテキストにします。

後方互換を考えた場合、オプションにすることも考えましたが、周囲を見る限り、必要ないと判断しました。