### PR TITLE
修正(cli.rb): issue.title内の角括弧をエスケープしてMarkdownのリンクを正しく表示

### DIFF
--- a/lib/furik/cli.rb
+++ b/lib/furik/cli.rb
@@ -23,8 +23,8 @@ module Furik
 
             next if start_date && date < start_date
             next if end_date && date > end_date
-
-            memo << "- [#{issue.title}](#{issue.html_url}):"
+            escaped_title = issue.title.gsub(/\[/, '\[').gsub(/\]/, '\]')
+            memo << "- [#{escaped_title}](#{issue.html_url})"
             memo << " (#{issue.body.plain.cut})" if issue.body && !issue.body.empty?
             memo << " #{issue.created_at.localtime.to_date}\n"
           end


### PR DESCRIPTION
issueやPRのタイトルに `[hoge]fuga` みたいに`[]`が入ってる場合にうまくマークダウンがパースされないのでエスケープしました。